### PR TITLE
Silence FutureWarning from python-miio

### DIFF
--- a/custom_components/dreame_vacuum/__init__.py
+++ b/custom_components/dreame_vacuum/__init__.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 import traceback
+import warnings
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL
 from pathlib import Path
 from .const import DOMAIN
+
+# Suppress python-miio FutureWarning on Python 3.13
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    module="miio.miot_device",
+)
+
 from .coordinator import DreameVacuumDataUpdateCoordinator
 
 PLATFORMS = (


### PR DESCRIPTION
## Summary
- ignore FutureWarning emitted by `python-miio` on Python 3.13

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880ad1c4d3c832d8665de3b043943f4